### PR TITLE
Release/0.3.1

### DIFF
--- a/repo/gorm/data_writer.go
+++ b/repo/gorm/data_writer.go
@@ -45,9 +45,8 @@ func (w *dataWriter) PartialUpdate(ctx context.Context, value interface{}) error
 	if err != nil {
 		return err
 	}
-	t := w.typeHandler.NewPtrToElement().Element()
 
-	err = w.db.Model(t).Updates(value).Find(value).Error
+	err = w.db.Model(value).Updates(value).Find(value).Error
 
 	if err != nil {
 		return err


### PR DESCRIPTION
partial update fixed when do we have more records already stored in database, it was returning an error indicating a primary key duplication exception.